### PR TITLE
Updated clusterrole apiVersion

### DIFF
--- a/kubeconfig-exporter/clusterrole.yaml
+++ b/kubeconfig-exporter/clusterrole.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: devtroncd
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cd-user


### PR DESCRIPTION
This PR is to fix error issues due to apiVersion for K8s 1.22 and above
rbac apiVersion v1 is there since K8s v1.19